### PR TITLE
fix: 분리된 카카오 로그인 예외 처리 및 JWT 토큰 subject를 memberId로 설정

### DIFF
--- a/src/main/java/com/runcombi/server/auth/jwt/JwtService.java
+++ b/src/main/java/com/runcombi/server/auth/jwt/JwtService.java
@@ -89,7 +89,7 @@ public class JwtService {
                 .setIssuedAt(now)
                 .setSubject(String.valueOf(memberId))
                 .setExpiration(new Date(now.getTime() + accessTokenExpireTime))  // 7일
-                .claim("memberId", memberId)
+                .setSubject(String.valueOf(memberId)) // memberId 값 subject 로 설정
                 .claim("role", role)
                 .signWith(key)
                 .compact();

--- a/src/main/java/com/runcombi/server/auth/kakao/service/KakaoLoginService.java
+++ b/src/main/java/com/runcombi/server/auth/kakao/service/KakaoLoginService.java
@@ -12,10 +12,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
@@ -56,10 +53,11 @@ public class KakaoLoginService {
             );
 
             Map<String, Object> body = response.getBody();
+            log.info("전달받은 body ::::: {}", body);
             Map<String, Object> kakaoAccount = (Map<String, Object>) body.get("kakao_account");
             if (kakaoAccount == null) {
                 // 유효하지 않은 카카오 토큰인 경우
-                log.error("invalid kakao token ::::: {}", kakaoAccessToken);
+                log.error("invalid kakao token(kakaoAcount == null) ::::: {}", kakaoAccessToken);
                 throw new CustomException(KAKAO_TOKEN_INVALID);
             }
             userEmail = (String) kakaoAccount.get("email");
@@ -67,9 +65,15 @@ public class KakaoLoginService {
             // 카카오 토큰이 만료된 경우
             log.error("expired kakao token ::::: {}", kakaoAccessToken);
             throw new CustomException(KAKAO_TOKEN_EXPIRED);
-        } catch(JwtException | HttpClientErrorException e) {
+        } catch(JwtException e) {
             // 유효하지 않은 카카오 토큰인 경우
-            log.error("invalid kakao token ::::: {}", kakaoAccessToken);
+            log.error("invalid kakao token(JwtException) ::::: {}", kakaoAccessToken);
+            throw new CustomException(KAKAO_TOKEN_INVALID);
+        } catch(HttpClientErrorException e) {
+            // 유효하지 않은 카카오 토큰인 경우
+            log.error("invalid kakao token(HttpClientErrorException) ::::: {}", kakaoAccessToken);
+            log.error("응답코드 ::::: {}", e.getStatusCode());
+            log.error("응답바디 ::::: {}", e.getResponseBodyAsString());
             throw new CustomException(KAKAO_TOKEN_INVALID);
         }
 

--- a/src/main/java/com/runcombi/server/domain/member/entity/Member.java
+++ b/src/main/java/com/runcombi/server/domain/member/entity/Member.java
@@ -51,6 +51,10 @@ public class Member extends BaseTimeEntity implements UserDetails {
 
     private int registerStep; // step : 1(계정 등록만), 2(필요 정보 기입해야 함)
 
+    private String profileImgUrl;
+
+    private String profileImgKey;
+
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 //    private final List<Pet> pets = new ArrayList<>();
 


### PR DESCRIPTION
- 카카오 로그인 관련 토큰처리 예외분리
- JWT 발급 시 subject에 회원 고유 ID인 memberId를 사용하도록 설정