### PR TITLE
fix: S3 펫 이미지 값 정상적으로 등록되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/runcombi/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/runcombi/server/domain/member/service/MemberService.java
@@ -126,6 +126,8 @@ public class MemberService {
 
         // 첫번째 펫 정보 저장
         Pet firstPet = petService.setPetDetail(member, petDetail);
+        petRepository.save(firstPet);
+
         if(petImage != null) {
             // 첫번째 펫 이미지 저장
             S3ImageReturnDto firstPetImageReturnDto = s3Service.uploadPetImage(petImage, firstPet.getPetId());


### PR DESCRIPTION
- MemberService 내 setMemberPetDetail 메소드실행 시  영속성 context 에 petImage 등록 전 Pet 정보 등록