### PR TITLE
fix: access 토큰, refresh 토큰 구분

### DIFF
--- a/src/main/java/com/runcombi/server/auth/jwt/JwtService.java
+++ b/src/main/java/com/runcombi/server/auth/jwt/JwtService.java
@@ -27,7 +27,7 @@ public class JwtService {
     private final UserDetailServiceImpl userDetailService;
 
     private Long accessTokenExpireTime = 1000L * 60 * 60 * 24 * 7; // 7일
-    private Long refreshTokenExpireTime = 1000L * 60 * 60 * 24 * 7; // 30일
+    private Long refreshTokenExpireTime = 1000L * 60 * 60 * 24 * 30; // 30일
 
     public String validateToken(String token) {
         Date now = new Date();

--- a/src/main/java/com/runcombi/server/auth/kakao/service/KakaoLoginService.java
+++ b/src/main/java/com/runcombi/server/auth/kakao/service/KakaoLoginService.java
@@ -95,8 +95,10 @@ public class KakaoLoginService {
                     .build();
             Member savedMember = memberRepository.save(newMember);
 
-            String accessToken = jwtService.createRefreshToken(savedMember.getMemberId(), savedMember.getRole());
+            String accessToken = jwtService.createAccessToken(savedMember.getMemberId(), savedMember.getRole());
             String refreshToken = jwtService.createRefreshToken(savedMember.getMemberId(), savedMember.getRole());
+            System.out.println(accessToken);
+            System.out.println(refreshToken);
 
             savedMember.updateRefreshToken(refreshToken);
 
@@ -111,7 +113,7 @@ public class KakaoLoginService {
             Member member = optionalMember.get();
             MemberStatus memberStatus = member.getIsActive();
 
-            String accessToken = jwtService.createRefreshToken(member.getMemberId(), member.getRole());
+            String accessToken = jwtService.createAccessToken(member.getMemberId(), member.getRole());
             String refreshToken = jwtService.createRefreshToken(member.getMemberId(), member.getRole());
 
             // 추가 정보 기입이 필요한 회원일때 응답 (Member 의 isActive 값이 PENDING_AGREE 또는 PENDING_MEMBER_DETAIL 일 경우 응답에 isRegistered("N") 을 담아 리턴


### PR DESCRIPTION
- 기존에 access 토큰과 refresh 토큰을 동일하게 처리하고 있었음
- access 토큰과 refresh 토큰을 분리